### PR TITLE
Make terminal background/foreground follow Emacs's theme.

### DIFF
--- a/eaf-pyqterminal.el
+++ b/eaf-pyqterminal.el
@@ -55,18 +55,14 @@ If alpha < 0, don't set alpha for cursor"
 
 (defcustom eaf-pyqterminal-color-schema
   ;; Tango Dark
-  '(("background" "#000000")
-    ("black" "#000000")
-    ("blue" "#3465a4")
+  '(("blue" "#3465a4")
     ("brown" "#fce94f")
     ("cyan" "#06989a")
     ("cursor" "#eeeeec")
-    ("foreground" "#ffffff")
     ("green" "#4e9a06")
     ("magenta" "#75507b")
     ("red" "#cc0000")
     ("yellow" "#c4a000")
-    ("white" "#d3d7cf")
     ("brightblack" "#555753")
     ("brightblue" "#729fcf")
     ("brightcyan" "#34e2e2")

--- a/eaf_pyqterm_widget.py
+++ b/eaf_pyqterm_widget.py
@@ -24,7 +24,7 @@ import sys
 
 import pyte
 from core.buffer import interactive
-from core.utils import get_emacs_func_result, get_emacs_vars
+from core.utils import *
 from PyQt6.QtCore import QRect, Qt
 from PyQt6.QtGui import (
     QBrush,
@@ -97,6 +97,15 @@ class QTerminalWidget(QWidget):
                 self.cursor_color = color
                 continue
             self.colors[name] = color
+
+        self.theme_mode = get_emacs_theme_mode()
+        theme_foreground_color = get_emacs_theme_foreground()
+        theme_background_color = get_emacs_theme_background()
+
+        self.colors["foreground"] = QColor(theme_foreground_color)
+        self.colors["background"] = QColor(theme_background_color)
+        self.colors["black"] = QColor(theme_background_color) if self.theme_mode == "dark" else QColor("#000000")
+        self.colors["white"] = QColor(theme_background_color) if self.theme_mode == "light" else QColor("#FFFFFF")
 
         self.pens["default"] = QPen(self.colors["foreground"])
         self.brushes["default"] = QBrush(self.colors["background"])
@@ -282,8 +291,12 @@ class QTerminalWidget(QWidget):
             elif same_text != "":
                 text_width = self.get_text_width(same_text)
 
-                fg = "white" if pre_char.fg == "default" else pre_char.fg
-                bg = "black" if pre_char.bg == "default" else pre_char.bg
+                if self.theme_mode == "dark":
+                    fg = "white" if pre_char.fg == "default" else pre_char.fg
+                    bg = "black" if pre_char.bg == "default" else pre_char.bg
+                else:
+                    fg = "black" if pre_char.fg == "default" else pre_char.fg
+                    bg = "white" if pre_char.bg == "default" else pre_char.bg
                 if pre_char.reverse:
                     fg, bg = bg, fg
 


### PR DESCRIPTION
![截图 2023-06-02 22-39-20](https://github.com/mumu-lhl/eaf-pyqterminal/assets/237487/55f9c863-c88f-4070-9cd1-5f342fdeea35)

![截图 2023-06-02 22-39-34](https://github.com/mumu-lhl/eaf-pyqterminal/assets/237487/9c1fe770-5267-4b7e-a2d6-0c94d835e3cc)

这个补丁让终端的前景色和背景色和Emacs主题保持一致。