### PR TITLE
确保等宽字体可以设置，并修复 C-x o 无法切换窗口的问题

### DIFF
--- a/eaf-pyqterminal.el
+++ b/eaf-pyqterminal.el
@@ -102,7 +102,6 @@ If alpha < 0, don't set alpha for cursor"
     ("C-u" . "eaf-send-key-sequence")
     ("C-v" . "eaf-send-key-sequence")
     ("C-w" . "eaf-send-key-sequence")
-    ("C-x" . "eaf-send-key-sequence")
     ("C-y" . "yank_text")
     ("C-z" . "eaf-send-key-sequence")
     ("M-f" . "eaf-send-key-sequence")

--- a/eaf-pyqterminal.el
+++ b/eaf-pyqterminal.el
@@ -20,7 +20,9 @@
   :group 'eaf-pyqterminal)
 
 (defcustom eaf-pyqterminal-font-family ""
-  "Font family of EAF pyqterminal."
+  "Font family of EAF pyqterminal, we will use system Mono font if user choose font is not exist.
+
+Recommend use Nerd font to render icon in terminal."
   :type 'string
   :group 'eaf-pyqterminal)
 

--- a/eaf_pyqterm_widget.py
+++ b/eaf_pyqterm_widget.py
@@ -31,6 +31,7 @@ from PyQt6.QtGui import (
     QColor,
     QFont,
     QFontMetrics,
+    QFontDatabase,
     QKeyEvent,
     QPainter,
     QPen,
@@ -91,6 +92,8 @@ class QTerminalWidget(QWidget):
             )
         )
 
+        self.ensure_font_exist()
+
         for name, color_str in color_schema:
             color = QColor(color_str)
             if name == "cursor":
@@ -136,6 +139,11 @@ class QTerminalWidget(QWidget):
         self.pixmap = QPixmap(self.width(), self.height())
 
         self.startTimer(self.refresh_ms)
+
+    def ensure_font_exist(self):
+        '''Use system Mono font if user's font is not exist.'''
+        if self.font_family not in QFontDatabase.families():
+            self.font_family = QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont).family()
 
     def new_font(self, style=[]):
         font = QFont()


### PR DESCRIPTION
发了两个补丁：

1. ensure_font_exists 这个函数的作用： 如果用户设置的字体不存在， 就选择系统等宽字体， 确保终端渲染没有问题
2. 移除 C-x 的绑定， 这样会导致 C-x o 这样的默认按键无法使用， 用户分屏以后没法切换窗口， EAF有机制可以转发按键序列， 比如用 C-c C-x 来发送 C-x 序列