### PR TITLE
The scrolling ratio is adjusted according to the angle delta of scroll event.

### DIFF
--- a/eaf_pyqterm_widget.py
+++ b/eaf_pyqterm_widget.py
@@ -457,11 +457,15 @@ class QTerminalWidget(QWidget):
 
     def wheelEvent(self, event: QWheelEvent):
         y = event.angleDelta().y()
+
+        ratio = abs(y) / 200
+
         if y > 0:
-            self.backend.screen.prev_page()
+            self.backend.scroll_down(ratio)
         else:
-            self.backend.screen.next_page()
-            self.update()
+            self.backend.scroll_up(ratio)
+
+        self.update()
 
     @interactive
     def yank_text(self):


### PR DESCRIPTION
给 BaseBackend 增加了两个函数： scroll_down 和 scroll_up。

这样滚动的增量会根据用户触摸板的力度来调节， 现在只是 next_page 和 prev_page， 跨度太大， 很容易一滚动就滚过了。

scroll_down 和 scroll_up 的代码和 next_page 和 prev_page 基本上是一样的， 唯一的不同是 ratio 是根据  event.angleDelta().y() 来计算的， 而不是 screen 定义时传入的固定 ratio 参数（默认是 0.5)