### PR TITLE
Try to change buffer's default directory when terminal change title.

### DIFF
--- a/eaf_pyqterm_buffer.py
+++ b/eaf_pyqterm_buffer.py
@@ -41,6 +41,7 @@ class AppBuffer(Buffer):
         backend.start_directory = arguments_dict["directory"]
 
         term = widget.QTerminalWidget()
+        term.buffer_id = buffer_id
         term.change_title = self.change_title
         term.backend.close_buffer = self.close_buffer
 

--- a/eaf_pyqterm_widget.py
+++ b/eaf_pyqterm_widget.py
@@ -22,7 +22,6 @@
 import math
 import os
 import sys
-import re
 from enum import Enum
 
 import pyte

--- a/eaf_pyqterm_widget.py
+++ b/eaf_pyqterm_widget.py
@@ -232,12 +232,15 @@ class QTerminalWidget(QWidget):
             self.try_change_default_directory(title)
 
     def try_change_default_directory(self, title):
-        if ":" in title:
-            path = os.path.expanduser(title.split(":")[1])
+        try:
+            if ":" in title:
+                path = os.path.expanduser(title.split(":")[1])
 
-            if os.path.exists(path):
-                directory = path if os.path.isdir(path) else os.path.dirname(path)
-                eval_in_emacs('eaf--change-default-directory', [self.buffer_id, directory])
+                if os.path.exists(path):
+                    directory = path if os.path.isdir(path) else os.path.dirname(path)
+                    eval_in_emacs('eaf--change-default-directory', [self.buffer_id, directory])
+        except:
+            pass
 
     def paint_text(self, painter: QPainter):
         screen = self.backend.screen

--- a/eaf_pyqterm_widget.py
+++ b/eaf_pyqterm_widget.py
@@ -22,6 +22,7 @@
 import math
 import os
 import sys
+import re
 from enum import Enum
 
 import pyte
@@ -228,6 +229,16 @@ class QTerminalWidget(QWidget):
         if self.title != title:
             self.title = title
             self.change_title(f"Term [{title}]")
+
+            self.try_change_default_directory(title)
+
+    def try_change_default_directory(self, title):
+        if ":" in title:
+            path = os.path.expanduser(title.split(":")[1])
+
+            if os.path.exists(path):
+                directory = path if os.path.isdir(path) else os.path.dirname(path)
+                eval_in_emacs('eaf--change-default-directory', [self.buffer_id, directory])
 
     def paint_text(self, painter: QPainter):
         screen = self.backend.screen


### PR DESCRIPTION
当终端的标题发生变化后， 尝试解析出标题里面的路径， 并改变终端 buffer 的 default-directory.

这样可以随着终端路径的变化， 可以通过 eaf-open-in-file-manager 命令方便的切换到对应的目录。