### PR TITLE
Return expression directly.

### DIFF
--- a/README.org
+++ b/README.org
@@ -22,6 +22,79 @@ It is recommended to install [[https://www.nerdfonts.com][Nerd Fonts]] to suppor
 | psutil                  | get child process information |
 | pywinpty (only Windows) | pty on Windows                |
 
+### The keybinding of EAF PyQterminal.
+
+| Key           | Event                           |
+| C-S-v         | yank_text                       |
+| C-a           | eaf-send-key-sequence           |
+| C-b           | eaf-send-key-sequence           |
+| C-c C-c       | eaf-send-second-key-sequence    |
+| C-c C-x       | eaf-send-second-key-sequence    |
+| C-c C-m       | eaf-send-second-key-sequence    |
+| C-d           | eaf-send-key-sequence           |
+| C-e           | eaf-send-key-sequence           |
+| C-f           | eaf-send-key-sequence           |
+| C-g           | eaf-send-key-sequence           |
+| C-h           | eaf-send-key-sequence           |
+| C-j           | eaf-send-key-sequence           |
+| C-k           | eaf-send-key-sequence           |
+| C-l           | eaf-send-key-sequence           |
+| C-n           | eaf-send-key-sequence           |
+| C-o           | eaf-send-key-sequence           |
+| C-p           | eaf-send-key-sequence           |
+| C-r           | eaf-send-key-sequence           |
+| C-s           | eaf-send-key-sequence           |
+| C-t           | eaf-send-key-sequence           |
+| C-u           | eaf-send-key-sequence           |
+| C-v           | scroll_down_page                |
+| C-w           | eaf-send-key-sequence           |
+| C-y           | yank_text                       |
+| C-z           | eaf-send-key-sequence           |
+| M-f           | eaf-send-key-sequence           |
+| M-b           | eaf-send-key-sequence           |
+| M-d           | eaf-send-key-sequence           |
+| M-c           | toggle_cursor_move_mode         |
+| M-k           | scroll_up                       |
+| M-j           | scroll_down                     |
+| M-v           | scroll_up_page                  |
+| M-<           | scroll_to_begin                 |
+| M->           | scroll_to_bottom                |
+| M-DEL         | eaf-send-alt-backspace-sequence |
+| M-<backspace> | eaf-send-alt-backspace-sequence |
+| <escape>      | eaf-send-escape-key             |
+
+### The keybinding of EAF PyQterminal Cursor Move Mode.
+
+| Key   | Event                   |
+| j     | next_line               |
+| k     | previous_line           |
+| l     | next_character          |
+| h     | previous_character      |
+| e     | next_word               |
+| b     | previous_word           |
+| J     | scroll_down             |
+| K     | scroll_up               |
+| H     | move_beginning_of_line  |
+| L     | move_end_of_line        |
+| d     | scroll_down_page        |
+| u     | scroll_up_page          |
+| v     | toggle_mark             |
+| y     | copy_text               |
+| C-a   | move_beginning_of_line  |
+| C-e   | move_end_of_line        |
+| C-n   | next_line               |
+| C-p   | previous_line           |
+| C-f   | next_character          |
+| C-b   | previous_character      |
+| C-v   | scroll_down_page        |
+| M-f   | next_word               |
+| M-b   | previous_word           |
+| M-v   | scroll_up_page          |
+| M-c   | toggle_cursor_move_mode |
+| M-w   | copy_text               |
+| C-SPC | toggle_mark             |
+| q     | toggle_cursor_move_mode |
+
 *** Thanks for them
 
 EAF PyQterminal uses code of these projects:

--- a/eaf_pyqterm_term.py
+++ b/eaf_pyqterm_term.py
@@ -53,20 +53,11 @@ class QTerminalScreen(HistoryScreen):
 
     @property
     def at_top(self):
-        if self.base == 0 and self.virtual_cursor.y == 0:
-            return True
-        else:
-            return False
+        return self.base == 0 and self.virtual_cursor.y == 0
 
     @property
     def at_bottom(self):
-        if (
-            not self.in_history
-            and self.virtual_cursor.y + 1 == self.get_last_blank_line()
-        ):
-            return True
-        else:
-            return False
+        return not self.in_history and self.virtual_cursor.y + 1 == self.get_last_blank_line()
 
     def bell(self):
         playsound(BELL_SOUND_PATH, False)


### PR DESCRIPTION
这样写代码简洁一点， 避免不必要的 return True 和 return False.

同时用 eaf-generate-keymap-doc 自动生成了按键到README