### PR TITLE
Add raw keyword 'r' before regex string, fix code failed on Python 312

### DIFF
--- a/eaf_pyqterm_utils.py
+++ b/eaf_pyqterm_utils.py
@@ -20,8 +20,8 @@ def generate_random_key(count: int, letters: str) -> list[str]:
 import re
 
 LINK_PATTERN = re.compile(r"(https?://(?:[\w-]+\.)+[\w-]+(?:/[\w/?%&=-]*)?)")
-WORD_PATTERN = re.compile("[\s,\._()=*\"'\[\]/-]")
-SYMBOL_PATTERN = re.compile("\s")
+WORD_PATTERN = re.compile(r"[\s,\._()=*\"'\[\]/-]")
+SYMBOL_PATTERN = re.compile(r"\s")
 
 
 def match_link(text: str) -> (dict[int, str], int):


### PR DESCRIPTION
Ref https://github.com/emacs-eaf/eaf-browser/issues/70