### PR TITLE
fix: do not work on windows

### DIFF
--- a/eaf_pyqterm_backend.py
+++ b/eaf_pyqterm_backend.py
@@ -7,7 +7,7 @@ import threading
 
 import psutil
 
-if platform == "Windows":
+if platform.system() == "Windows":
     from winpty import PtyProcess as pty
 else:
     import fcntl


### PR DESCRIPTION
It doesn't run properly on Windows.
Here are some error logs:
```
Traceback (most recent call last):
  File "c:\Users\Islatan\AppData\Roaming\.emacs.d\site-lisp\emacs-application-framework\core\utils.py", line 56, in on_signal_received
    self._func(obj, *args, **kwargs)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\Islatan\AppData\Roaming\.emacs.d\site-lisp\emacs-application-framework\eaf.py", line 156, in new_buffer
    self.create_buffer(buffer_id, url, module_path, arguments)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\Islatan\AppData\Roaming\.emacs.d\site-lisp\emacs-application-framework\eaf.py", line 171, in create_buffer
    spec.loader.exec_module(module)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "<frozen importlib._bootstrap_external>", line 1022, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "c:/Users/Islatan/AppData/Roaming/.emacs.d/site-lisp/emacs-application-framework/app/pyqterminal/eaf_pyqterm_buffer.py", line 13, in <module>
    from eaf_pyqterm_frontend import FrontendWidget
  File "c:\Users/Islatan/AppData/Roaming/.emacs.d/site-lisp/emacs-application-framework/app/pyqterminal\eaf_pyqterm_frontend.py", line 26, in <module>
    import eaf_pyqterm_backend as backend
  File "c:\Users/Islatan/AppData/Roaming/.emacs.d/site-lisp/emacs-application-framework/app/pyqterminal\eaf_pyqterm_backend.py", line 13, in <module>
    import fcntl
ModuleNotFoundError: No module named 'fcntl'
```