### PR TITLE
fix: correct text alignment to resolve cursor positioning issue

### DIFF
--- a/eaf_pyqterm_frontend.py
+++ b/eaf_pyqterm_frontend.py
@@ -42,7 +42,7 @@ KEY_DICT = {
     Qt.Key.Key_Up: CSI_C0 + "A",
 }
 
-align = Qt.AlignmentFlag.AlignBottom | Qt.AlignmentFlag.AlignHCenter
+align = Qt.AlignmentFlag.AlignBottom | Qt.AlignmentFlag.AlignLeft
 
 LineType = Enum("LineType", ("Underline", "StrikeOut"))
 StyleType = Enum("StyleType", ("Bold", "Italics", "Underline", "StrikeOut"))


### PR DESCRIPTION
## Problem
The original text alignment caused a half-character misalignment between characters and the cursor position.
<img width="73" height="17" alt="image" src="https://github.com/user-attachments/assets/bac4a5eb-0cb8-4cf6-82d5-ce220ba32f3c" />
## Solution
Fixed this issue by modifying the align property to ensure proper character-cursor alignment.

