### PR TITLE
fix: reverse width and height on Windows

### DIFF
--- a/eaf_pyqterm_backend.py
+++ b/eaf_pyqterm_backend.py
@@ -84,7 +84,7 @@ class Pty:
             pass
 
     def _resize_winpty(self, width, height):
-        self.pty.setwinsize(width, height)
+        self.pty.setwinsize(cols=width, rows=height)
 
     def getcwd(self):
         pid = self.pty.pid if platform.system() == "Windows" else self.p_pid

--- a/eaf_pyqterm_backend.py
+++ b/eaf_pyqterm_backend.py
@@ -51,7 +51,7 @@ class Pty:
             argv,
             start_directory,
             env,
-            (int(env["COLUMNS"]), int(env["LINES"])),
+            (int(env["LINES"]), int(env["COLUMNS"])),
         )
 
     def read(self):


### PR DESCRIPTION
## Issue
#50 mentioned that when opening a terminal on Windows, it has truncated line issue. When typing commands or using some tools such as fzf, the lines exceed the width are truncated.

## Solution
1. Fix the truncated line issue with keyword arguments on Windows.
2. Fix the issue of reverse parameters to OpenConsole.exe during launch time on Windows by exchanging COLUMNS and LINES.