### PR TITLE
fix: fix keymap corruption when switching cursor move mode

### DIFF
--- a/eaf-pyqterminal.el
+++ b/eaf-pyqterminal.el
@@ -212,12 +212,15 @@ If ALWAYS-NEW is non-nil, always open a new terminal for the dedicated DIR."
       "ipython.exe"
     "ipython"))
 
-(defun eaf--toggle-cursor-move-mode (status)
+(defun eaf--toggle-cursor-move-mode (buffer-id status)
   "Toggle Cursor Move Mode."
-  (if status
-      (eaf--gen-keybinding-map eaf-pyqterminal-cursor-move-mode-keybinding t)
-    (eaf--gen-keybinding-map eaf-pyqterminal-keybinding))
-  (setq eaf--buffer-map-alist (list (cons t eaf-mode-map))))
+  (let ((buffer (eaf-get-buffer buffer-id)))
+    (when buffer
+      (with-current-buffer buffer
+        (if status
+            (eaf--gen-keybinding-map eaf-pyqterminal-cursor-move-mode-keybinding t)
+          (eaf--gen-keybinding-map eaf-pyqterminal-keybinding))
+        (setq eaf--buffer-map-alist (list (cons t eaf-mode-map)))))))
 
 (defun eaf-pyqterminal-get-color-schema ()
   (if eaf-pyqterminal-color-schema-from-emacs

--- a/eaf_pyqterm_buffer.py
+++ b/eaf_pyqterm_buffer.py
@@ -24,6 +24,8 @@ class AppBuffer(Buffer):
         self.term = FrontendWidget(argv, start_directory)
 
         self.term.buffer_id = buffer_id
+        self.term.backend.screen.buffer_id = buffer_id
+        self.term.backend.buffer_screen.buffer_id = buffer_id
         self.term.change_title = self.change_title
         self.term.backend.close_buffer = self.close_buffer
         self.term.send_input_message = self.send_input_message

--- a/eaf_pyqterm_frontend.py
+++ b/eaf_pyqterm_frontend.py
@@ -653,7 +653,7 @@ class FrontendWidget(QWidget):
                 screen.cursor_move_mode = False
                 screen.sync_cursor()
 
-                eval_in_emacs("eaf--toggle-cursor-move-mode", ["'nil"])
+                eval_in_emacs("eaf--toggle-cursor-move-mode", [self.buffer_id, "'nil"])
 
             self.releaseMouse()
 

--- a/eaf_pyqterm_term.py
+++ b/eaf_pyqterm_term.py
@@ -45,6 +45,7 @@ class TerminalScreen(HistoryScreen):
         self.old_marker_cursor = Cursor(0, 0)
 
         self.mouse = False
+        self.buffer_id = ""
 
     def absolute_y(self, line_num: int) -> int:
         return self.base + line_num
@@ -247,7 +248,7 @@ class TerminalScreen(HistoryScreen):
         self.fake_marker = False
         self.mouse = False
 
-        eval_in_emacs("eaf--toggle-cursor-move-mode", ["'t" if status else "'nil"])
+        eval_in_emacs("eaf--toggle-cursor-move-mode", [self.buffer_id, "'t" if status else "'nil"])
 
     def adjust_x(self, y: int) -> None:
         """Recalibrate the x of the virtual cursor."""
@@ -493,7 +494,7 @@ class TerminalScreen(HistoryScreen):
                 if self.in_history:
                     self.cursor_move_mode = False
                     self.virtual_cursor.hidden = True
-                    eval_in_emacs("eaf--toggle-cursor-move-mode", ["'nil"])
+                    eval_in_emacs("eaf--toggle-cursor-move-mode", [self.buffer_id, "'nil"])
                 else:
                     self.toggle_cursor_move_mode(False)
 


### PR DESCRIPTION
Fix cursor move mode keymap toggling the wrong buffer when multiple terminals are open